### PR TITLE
fix: Improve response time — show GM message immediately and granular step status (closes #12)

### DIFF
--- a/src/components/chat/AgentStatus.tsx
+++ b/src/components/chat/AgentStatus.tsx
@@ -1,28 +1,29 @@
 import { useChatStore } from '../../stores/chatStore';
-import { useAuthStore } from '../../stores/authStore';
+
+const STEP_LABELS: Record<string, string> = {
+  loading:       'loading context...',
+  historian:     'historian is researching...',
+  barrister:     'analyzing mechanics...',
+  gm:            'GM is writing...',
+  finalizing:    'recording events...',
+  world_creator: 'building the world...',
+  char_creator:  'creating character...',
+};
 
 export function AgentStatus() {
-  const { isProcessing, isSending, error, clearError, worldLockedBy, worldLockedCharacter } = useChatStore();
-  const { user } = useAuthStore();
+  const { isProcessing, isSending, processingStep, error, clearError } = useChatStore();
   
-  // Show when sending, processing, or there's an error
   const isActive = isSending || isProcessing;
   
   if (!isActive && !error) {
     return null;
   }
   
-  // Determine if this is a "soft" error (timeout while still processing)
   const isSoftError = isActive && error;
-  
-  // Determine if another user has the lock
-  const isLockedByOther = worldLockedBy && user && worldLockedBy !== user.id;
-  
-  // Generate the status message
-  let statusMessage = isSending ? 'sending...' : 'GM is thinking...';
-  if (isLockedByOther && worldLockedCharacter) {
-    statusMessage = `GM is responding to ${worldLockedCharacter}...`;
-  }
+
+  const statusMessage = isSending
+    ? 'sending...'
+    : (processingStep ? (STEP_LABELS[processingStep] ?? 'GM is thinking...') : 'GM is thinking...');
   
   return (
     <div 
@@ -40,27 +41,15 @@ export function AgentStatus() {
             <span className="flex gap-1 items-center flex-shrink-0">
               <span 
                 className="w-1.5 h-1.5 rounded-full animate-bounce"
-                style={{ 
-                  backgroundColor: isLockedByOther ? 'var(--text-muted)' : 'var(--accent-primary)',
-                  animationDelay: '0ms',
-                  animationDuration: '0.6s',
-                }}
+                style={{ backgroundColor: 'var(--accent-primary)', animationDelay: '0ms', animationDuration: '0.6s' }}
               />
               <span 
                 className="w-1.5 h-1.5 rounded-full animate-bounce"
-                style={{ 
-                  backgroundColor: isLockedByOther ? 'var(--text-muted)' : 'var(--accent-primary)',
-                  animationDelay: '150ms',
-                  animationDuration: '0.6s',
-                }}
+                style={{ backgroundColor: 'var(--accent-primary)', animationDelay: '150ms', animationDuration: '0.6s' }}
               />
               <span 
                 className="w-1.5 h-1.5 rounded-full animate-bounce"
-                style={{ 
-                  backgroundColor: isLockedByOther ? 'var(--text-muted)' : 'var(--accent-primary)',
-                  animationDelay: '300ms',
-                  animationDuration: '0.6s',
-                }}
+                style={{ backgroundColor: 'var(--accent-primary)', animationDelay: '300ms', animationDuration: '0.6s' }}
               />
             </span>
             <span className="flex-shrink-0">{statusMessage}</span>


### PR DESCRIPTION
## Summary

Companion frontend changes for rpg-agents#14 (issue #12). The GM message now appears in the chat as soon as the backend broadcasts `gm_response_ready` — before bard/accountant/scribe finish post-processing. The status bar is updated to show granular per-agent phase labels ("historian is researching...", "GM is writing...", "recording events...") and uses a single unified style for all processing states (own message or another user's).

## Root Cause

The UI only showed the GM message after `processing_complete` fired (end of entire graph). The status bar also used different text/colors depending on whether the current user or another user had the lock, creating an inconsistent experience.

## Changes

- `src/stores/chatStore.ts`
  - Added `processingStep: string | null` to state, initialized and reset on world switch, `processing_started`, `processing_complete`, and `processing_error`
  - Added handler for `processing_step` SSE event → updates `processingStep`
  - Added handler for `gm_response_ready` SSE event → immediately inserts GM message into `messageList` (with dedup guard), leaving `isProcessing = true`

- `src/components/chat/AgentStatus.tsx`
  - Removed `isLockedByOther` / `worldLockedBy` branching entirely
  - Added `STEP_LABELS` map for step → display text
  - `statusMessage` now reads from `processingStep` when available, falling back to "GM is thinking..."
  - Dot color always `var(--accent-primary)` — no conditional coloring based on lock owner

## How to Test

1. Send a message in a world
2. Watch the status bar cycle through: "loading context..." → "historian is researching..." → "analyzing mechanics..." → "GM is writing..."
3. Expected: GM message appears in the chat while the status bar still shows "recording events..."
4. Expected: Status bar clears when `processing_complete` fires
5. With two browser sessions: both sessions should show the same accent-colored dots + step label, no difference between the user who sent vs. the observer

## Linked Issue
Closes #12

## Linked Bug Reports
N/A — this is a feature/improvement issue
