### PR TITLE
fix: add ProcessingStepEvent and GmResponseReadyEvent to UpdateEvent union (closes #3)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -303,7 +303,17 @@ export interface ProcessingErrorEvent {
   timestamp: string;
 }
 
-export type UpdateEvent = ProcessingStartedEvent | ProcessingCompleteEvent | ProcessingErrorEvent | ConnectedEvent | { type: 'ping' } | { type: 'error'; message: string };
+export interface ProcessingStepEvent {
+  type: 'processing_step';
+  step: string;
+}
+
+export interface GmResponseReadyEvent {
+  type: 'gm_response_ready';
+  message: import('../types').Message;
+}
+
+export type UpdateEvent = ProcessingStartedEvent | ProcessingCompleteEvent | ProcessingErrorEvent | ConnectedEvent | ProcessingStepEvent | GmResponseReadyEvent | { type: 'ping' } | { type: 'error'; message: string };
 
 // World updates API (multi-user sync notifications)
 export const updates = {


### PR DESCRIPTION
## Summary

`npm run build` was failing because `UpdateEvent` in `src/services/api.ts` was not updated when the two new SSE event types (`processing_step` and `gm_response_ready`) were added to `chatStore.ts` as part of issue #12. TypeScript narrowed the type to `never` in those branches, causing property access errors on `data.step` and `data.message`.

## Root Cause

`chatStore.ts` was updated to handle `processing_step` and `gm_response_ready` events, but the corresponding type definitions were missing from the `UpdateEvent` discriminated union in `api.ts`.

## Changes

- `src/services/api.ts` — Added `ProcessingStepEvent` (`{ type: 'processing_step'; step: string }`) and `GmResponseReadyEvent` (`{ type: 'gm_response_ready'; message: Message }`) interfaces, and included both in the `UpdateEvent` union type.

## How to Test

```
npm run build
```

Expected: builds successfully with no TypeScript errors.

## Linked Issue
Closes #3
